### PR TITLE
Normalize game log casing and deduplicate appends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.zip
 *.log
 nba-db/
+data/external/
 data/raw/*.csv
 data/raw/*.json
 .eggs/

--- a/src/nbapredictor/nbadb_sync.py
+++ b/src/nbapredictor/nbadb_sync.py
@@ -35,6 +35,25 @@ SEASON_TYPES: tuple[str, ...] = (
     "Pre Season",
 )
 
+NBA_API_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+    "Origin": "https://www.nba.com",
+    "Referer": "https://www.nba.com/",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-site",
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    ),
+    "x-nba-stats-origin": "stats",
+    "x-nba-stats-token": "true",
+}
+
+DEFAULT_TIMEOUT = 15
+
 
 @dataclass
 class UpdateSummary:
@@ -161,6 +180,8 @@ def _fetch_game_logs_for_date(target_date: date, retries: int = 3, pause: float 
                     season_type_all_star=season_type,
                     date_from_nullable=date_str,
                     date_to_nullable=date_str,
+                    headers=NBA_API_HEADERS,
+                    timeout=DEFAULT_TIMEOUT,
                 )
                 frame = endpoint.get_data_frames()[0]
                 if not frame.empty:
@@ -213,6 +234,8 @@ def _fetch_game_logs_for_season(season: str, retries: int = 3, pause: float = 1.
                     league_id="00",
                     season=season,
                     season_type_all_star=season_type,
+                    headers=NBA_API_HEADERS,
+                    timeout=DEFAULT_TIMEOUT,
                 )
                 frame = endpoint.get_data_frames()[0]
                 if not frame.empty:
@@ -467,7 +490,7 @@ def update_raw_data(
 
     stop = _parse_date(end_date)
     if stop is None:
-        stop = date.today() - timedelta(days=1)
+        stop = date.today()
 
     if fetch_all_history:
         start = HISTORICAL_START_DATE

--- a/tests/test_nbadb_sync.py
+++ b/tests/test_nbadb_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import types
 from datetime import date
 from pathlib import Path
 
@@ -142,3 +143,112 @@ def test_bootstrap_kaggle_imports_dataset(tmp_path, monkeypatch):
     assert manifest["last_updated"] == "2024-10-26"
     assert set(manifest["historical_seasons"]) >= {"2023-24", "2024-25"}
     assert manifest["bootstrap"]["dataset"] == nbadb_sync.KAGGLE_DATASET_ID
+
+
+def test_bootstrap_kaggle_dump_invokes_cli(tmp_path, monkeypatch):
+    commands: list[tuple[tuple[str, ...], bool]] = []
+
+    def fake_which(executable: str) -> str:
+        assert executable == "kaggle"
+        return "/usr/bin/kaggle"
+
+    def fake_run(args, *, check):
+        commands.append((tuple(args), check))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(nbadb_sync.shutil, "which", fake_which)
+    monkeypatch.setattr(nbadb_sync.subprocess, "run", fake_run)
+
+    destination = tmp_path / "dataset"
+    result = nbadb_sync.bootstrap_kaggle_dump(destination)
+
+    assert result == destination
+    assert destination.exists()
+    assert commands == [
+        (
+            (
+                "kaggle",
+                "datasets",
+                "download",
+                "--unzip",
+                "-p",
+                str(destination),
+                "-d",
+                nbadb_sync.KAGGLE_DATASET_ID,
+            ),
+            True,
+        )
+    ]
+
+
+def test_bootstrap_kaggle_dump_missing_cli(tmp_path, monkeypatch):
+    monkeypatch.setattr(nbadb_sync.shutil, "which", lambda executable: None)
+
+    with pytest.raises(FileNotFoundError):
+        nbadb_sync.bootstrap_kaggle_dump(tmp_path / "dataset")
+
+
+def test_fetch_game_logs_for_date_uses_headers_and_timeout(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_leaguegamelog(*, league_id, season, season_type_all_star, date_from_nullable, date_to_nullable, headers, timeout):
+        calls.append(
+            {
+                "league_id": league_id,
+                "season": season,
+                "season_type": season_type_all_star,
+                "headers": headers,
+                "timeout": timeout,
+                "date_from": date_from_nullable,
+                "date_to": date_to_nullable,
+            }
+        )
+        return types.SimpleNamespace(
+            get_data_frames=lambda: [pd.DataFrame({"GAME_ID": ["1"], "SEASON_ID": ["1"]})]
+        )
+
+    monkeypatch.setattr(nbadb_sync.leaguegamelog, "LeagueGameLog", fake_leaguegamelog)
+
+    frame = nbadb_sync._fetch_game_logs_for_date(date(2024, 10, 5), retries=1)
+
+    assert not frame.empty
+    assert {call["season_type"] for call in calls} == set(nbadb_sync.SEASON_TYPES)
+    assert all(call["headers"] == nbadb_sync.NBA_API_HEADERS for call in calls)
+    assert all(call["timeout"] == nbadb_sync.DEFAULT_TIMEOUT for call in calls)
+
+
+def test_update_raw_data_defaults_to_today(monkeypatch, tmp_path):
+    class FakeDate(date):
+        @classmethod
+        def today(cls) -> "FakeDate":
+            return cls(2024, 10, 5)
+
+    processed: list[date] = []
+
+    def fake_fetch_game_logs(target_date: date) -> pd.DataFrame:
+        processed.append(target_date)
+        return pd.DataFrame(
+            {
+                "GAME_ID": [target_date.strftime("%Y%m%d")],
+                "TEAM_ID": ["1610612737"],
+                "GAME_DATE": [target_date.isoformat()],
+            }
+        )
+
+    manifest_path = tmp_path / nbadb_sync.MANIFEST_FILENAME
+    manifest_path.write_text(json.dumps({"last_updated": "2024-10-03"}))
+
+    monkeypatch.setattr(nbadb_sync, "date", FakeDate)
+    monkeypatch.setattr(nbadb_sync, "_fetch_game_logs_for_date", fake_fetch_game_logs)
+    monkeypatch.setattr(
+        nbadb_sync, "fetch_dataset_metadata", lambda session=None: {"title": "NBA Database"}
+    )
+
+    summary = nbadb_sync.update_raw_data(output_dir=tmp_path)
+
+    assert summary.processed_dates == [date(2024, 10, 4), date(2024, 10, 5)]
+    assert processed == summary.processed_dates
+    assert len(summary.downloaded_files) == 2
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["last_updated"] == "2024-10-05"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -34,9 +34,9 @@ def test_daily_fetch_all_history(monkeypatch, tmp_path):
     assert records == [{"called": True}]
     assert result.output_path == tmp_path / "data/raw/game.csv"
     saved = pd.read_csv(result.output_path)
-    expected = frame.copy()
-    saved["GAME_ID"] = saved["GAME_ID"].astype(int)
-    expected["GAME_ID"] = expected["GAME_ID"].astype(int)
+    expected = frame.rename(columns=str.lower)
+    saved["game_id"] = saved["game_id"].astype(int)
+    expected["game_id"] = expected["game_id"].astype(int)
     pd.testing.assert_frame_equal(saved, expected, check_dtype=False)
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import date
 import types
 
+from requests import exceptions as requests_exceptions
+
 import pandas as pd
 import pytest
 
@@ -43,6 +45,18 @@ def test_daily_incremental_appends(monkeypatch, tmp_path):
     assert result.rows_written == len(new_frame)
 
 
+def test_next_start_date_handles_lowercase_columns(monkeypatch, tmp_path):
+    _setup_config(tmp_path, monkeypatch)
+    game_csv = tmp_path / "data/raw/game.csv"
+    game_csv.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({
+        "game_id": ["0001"],
+        "game_date": ["2020-01-01"],
+    }).to_csv(game_csv, index=False)
+
+    assert update._next_start_date(game_csv) == date(2020, 1, 2)
+
+
 def test_daily_without_history_file_raises(monkeypatch, tmp_path):
     _setup_config(tmp_path, monkeypatch)
     with pytest.raises(FileNotFoundError):
@@ -77,6 +91,61 @@ def test_init_writes_all_resources(monkeypatch, tmp_path):
     assert (tmp_path / "data/raw/game_summary.csv").exists()
 
 
+def test_write_dataframe_deduplicates(monkeypatch, tmp_path):
+    _setup_config(tmp_path, monkeypatch)
+    path = tmp_path / "data/raw/game.csv"
+    frame = pd.DataFrame({
+        "GAME_ID": ["0001", "0001"],
+        "TEAM_ID": ["1610612737", "1610612737"],
+        "SEASON_TYPE": ["Regular Season", "Regular Season"],
+    })
+
+    rows = update._write_dataframe(
+        path,
+        frame,
+        append=False,
+        deduplicate_subset=update.GAME_LOG_PRIMARY_KEY,
+    )
+
+    saved = pd.read_csv(path)
+    assert rows == 1
+    assert len(saved) == 1
+    assert list(saved.columns) == [col.lower() for col in frame.columns]
+
+
+def test_write_dataframe_append_deduplicates(monkeypatch, tmp_path):
+    _setup_config(tmp_path, monkeypatch)
+    path = tmp_path / "data/raw/game.csv"
+    initial = pd.DataFrame({
+        "GAME_ID": ["0001"],
+        "TEAM_ID": ["1610612737"],
+        "SEASON_TYPE": ["Regular Season"],
+    })
+    update._write_dataframe(
+        path,
+        initial,
+        append=False,
+        deduplicate_subset=update.GAME_LOG_PRIMARY_KEY,
+    )
+
+    duplicate = pd.DataFrame({
+        "game_id": ["0001"],
+        "team_id": ["1610612737"],
+        "season_type": ["Regular Season"],
+    })
+
+    rows = update._write_dataframe(
+        path,
+        duplicate,
+        append=True,
+        deduplicate_subset=update.GAME_LOG_PRIMARY_KEY,
+    )
+
+    saved = pd.read_csv(path)
+    assert rows == 0
+    assert len(saved) == 1
+
+
 def test_get_league_game_log_from_date_bounds(monkeypatch):
     calls: list[tuple[str, str, str]] = []
 
@@ -95,3 +164,76 @@ def test_get_league_game_log_from_date_bounds(monkeypatch):
 
     assert not frame.empty
     assert any(season == "2020-21" for season, *_ in calls)
+
+
+def test_call_with_retry_retries_then_succeeds(monkeypatch):
+    attempts = 0
+    sleeps: list[int] = []
+
+    def fake_sleep(seconds: int) -> None:
+        sleeps.append(seconds)
+
+    timeouts_seen: list[int | float] = []
+
+    def flaky_call(timeout):
+        timeouts_seen.append(timeout)
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise requests_exceptions.ReadTimeout("timeout", request=None)
+        return pd.DataFrame({"value": [1]})
+
+    monkeypatch.setattr(update.time, "sleep", fake_sleep)
+
+    frame = update._call_with_retry("example", flaky_call)
+
+    assert attempts == 3
+    assert sleeps == [1, 2]
+    assert timeouts_seen == [update.DEFAULT_TIMEOUT, update.DEFAULT_TIMEOUT, update.DEFAULT_TIMEOUT]
+    assert not frame.empty
+
+
+def test_call_with_retry_exhausts_attempts(monkeypatch):
+    attempts = 0
+    sleeps: list[int] = []
+
+    def fake_sleep(seconds: int) -> None:
+        sleeps.append(seconds)
+
+    def failing_call(timeout):
+        nonlocal attempts
+        attempts += 1
+        raise requests_exceptions.Timeout("timeout", request=None)
+
+    monkeypatch.setattr(update.time, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        update._call_with_retry("player", failing_call)
+
+    assert "Failed to fetch player" in str(excinfo.value)
+    assert attempts == update.MAX_REQUEST_RETRIES
+    assert sleeps == [1, 2, 4, 8]
+
+
+def test_call_with_retry_respects_timeout_plan(monkeypatch):
+    attempts = 0
+    seen_timeouts: list[int | float] = []
+
+    def fake_sleep(seconds: int) -> None:
+        pass
+
+    def failing_call(timeout):
+        nonlocal attempts
+        attempts += 1
+        seen_timeouts.append(timeout)
+        raise requests_exceptions.ConnectTimeout("timeout", request=None)
+
+    monkeypatch.setattr(update.time, "sleep", fake_sleep)
+
+    custom_timeouts = (1, 2, 4)
+
+    with pytest.raises(RuntimeError):
+        update._call_with_retry("custom", failing_call, timeouts=custom_timeouts)
+
+    assert attempts == update.MAX_REQUEST_RETRIES
+    assert seen_timeouts == [1, 2, 4, 4, 4]


### PR DESCRIPTION
## Summary
- canonicalize NBA game log columns and key values so incremental updates detect existing dates reliably
- deduplicate game log writes for both full history and incremental paths while preserving appended row counts
- extend the test suite to cover lowercase data, deduplication behaviour, and updated CLI expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3313e7630832da5be1a3294ad293f