### PR TITLE
Refactor bootstrap and daily update pipeline with DuckDB schema support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ __pycache__/
 *.zip
 *.log
 nba-db/
+data/external/
 data/raw/*.csv
 data/raw/*.json
+data/*.duckdb
 .eggs/
 build/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: load-db build-schema db
+
+load-db:
+	python scripts/load_duckdb.py
+
+build-schema:
+	duckdb -c ".read sql/build_schema.sql"
+
+db: load-db build-schema

--- a/bin/validate_game_csv.py
+++ b/bin/validate_game_csv.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Quick validation helper for the consolidated game log."""
+from __future__ import annotations
+
+import sys
+
+import pandas as pd
+
+from nba_db.paths import GAME_CSV
+
+
+def main() -> int:
+    game_path = GAME_CSV
+    if not game_path.exists():
+        print(f"No game.csv found at {game_path}", file=sys.stderr)
+        return 1
+
+    frame = pd.read_csv(game_path)
+    frame.columns = [col.lower() for col in frame.columns]
+    if "game_date" not in frame.columns:
+        print("game_date column missing", file=sys.stderr)
+        return 1
+    frame["game_date"] = pd.to_datetime(frame["game_date"], errors="coerce")
+
+    missing_dates = frame["game_date"].isna().sum()
+    print(f"Loaded {len(frame):,} rows from {game_path}")
+    print(f"Missing game_date entries: {missing_dates}")
+    print("Rows by season_type:")
+    if "season_type" in frame.columns:
+        counts = frame["season_type"].fillna("<missing>").value_counts().sort_index()
+        for season_type, count in counts.items():
+            print(f"  {season_type}: {count:,}")
+    else:
+        print("  season_type column missing")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "nba_api>=1.5.7",
   "python-dateutil>=2.9",
   "pyyaml>=6.0",
+  "duckdb>=1.0",
 ]
 
 [tool.setuptools]

--- a/run_init.py
+++ b/run_init.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
-"""One-time bootstrap script for the NBA data pipeline."""
+"""Bootstrap Kaggle data into the local ``data/raw`` directory."""
 from __future__ import annotations
 
+import argparse
+import logging
 import os
+import shutil
+import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
+
+import pandas as pd
+
+from nba_db.paths import GAME_CSV, RAW_DIR, ROOT
+
+
+DEFAULT_DATASET_ID = "wyattowalsh/basketball"
+DEFAULT_SEASON_TYPE = "Regular Season"
 
 
 _NUMERIC_ENV_DEFAULTS = {
@@ -22,27 +33,160 @@ def _configure_numeric_environment() -> None:
         os.environ.setdefault(key, value)
 
 
-def main() -> None:
-    project_root = Path(__file__).resolve().parent
-    sys.path.insert(0, str(project_root))
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download and normalise Kaggle bootstrap data")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download the Kaggle dataset even if local files already exist",
+    )
+    parser.add_argument(
+        "--dataset-id",
+        default=DEFAULT_DATASET_ID,
+        help="Kaggle dataset identifier to download",
+    )
+    return parser.parse_args(argv)
+
+
+def _ensure_kaggle_cli() -> None:
+    if shutil.which("kaggle") is not None:
+        return
+    message = (
+        "Kaggle CLI not found. Install kaggle and configure credentials via "
+        "~/.kaggle/kaggle.json or KAGGLE_USERNAME/KAGGLE_KEY before running run_init.py"
+    )
+    raise SystemExit(message)
+
+
+def _clear_raw_dir() -> None:
+    if not RAW_DIR.exists():
+        return
+    for entry in RAW_DIR.iterdir():
+        if entry.is_file() or entry.is_symlink():
+            entry.unlink()
+        elif entry.is_dir():
+            shutil.rmtree(entry)
+
+
+def _download_dataset(dataset_id: str, *, force: bool) -> None:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    if not force and any(RAW_DIR.glob("*.csv")):
+        logging.info("Existing Kaggle exports detected; skipping download (use --force to re-download)")
+        return
+
+    if force:
+        logging.info("--force supplied; clearing %s before download", RAW_DIR)
+        _clear_raw_dir()
+
+    logging.info("Downloading %s into %s", dataset_id, RAW_DIR)
+    try:
+        subprocess.run(
+            [
+                "kaggle",
+                "datasets",
+                "download",
+                "-d",
+                dataset_id,
+                "-p",
+                str(RAW_DIR),
+                "--unzip",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - requires kaggle CLI
+        logging.error("Kaggle download failed: %s", exc.stderr.decode() if exc.stderr else exc)
+        raise SystemExit(1) from exc
+
+
+def _normalise_game_csv() -> pd.DataFrame:
+    alt_path = RAW_DIR / "games.csv"
+    if alt_path.exists() and not GAME_CSV.exists():
+        logging.info("Renaming %s -> %s", alt_path.name, GAME_CSV.name)
+        alt_path.rename(GAME_CSV)
+
+    if not GAME_CSV.exists():
+        raise SystemExit(
+            f"Expected {GAME_CSV} after Kaggle download. Ensure the dataset contains game.csv/games.csv"
+        )
+
+    frame = pd.read_csv(GAME_CSV)
+    if frame.empty:
+        frame.columns = [col.lower() for col in frame.columns]
+    else:
+        frame.columns = frame.columns.str.lower()
+
+    if "game_date" in frame.columns:
+        frame["game_date"] = pd.to_datetime(frame["game_date"], errors="coerce")
+
+    if "season_type" not in frame.columns:
+        frame["season_type"] = DEFAULT_SEASON_TYPE
+    else:
+        frame["season_type"] = (
+            frame["season_type"].fillna(DEFAULT_SEASON_TYPE).replace("", DEFAULT_SEASON_TYPE)
+        )
+
+    for column in ("season_id", "game_id", "team_id"):
+        if column in frame.columns:
+            frame[column] = frame[column].astype(str).str.strip()
+
+    tmp_path = GAME_CSV.with_suffix(".tmp")
+    frame.to_csv(tmp_path, index=False)
+    os.replace(tmp_path, GAME_CSV)
+    return frame
+
+
+def _log_summary(frame: pd.DataFrame) -> None:
+    row_count = len(frame)
+    if "game_date" in frame.columns and not frame["game_date"].dropna().empty:
+        min_date = frame["game_date"].min()
+        max_date = frame["game_date"].max()
+        window = f"{min_date.date()} → {max_date.date()}"
+    else:
+        window = "unknown"
+
+    logging.info("Normalised game.csv with %s rows covering %s", row_count, window)
+
+    csv_paths = sorted(RAW_DIR.glob("*.csv"))
+    if not csv_paths:
+        logging.warning("No CSV files detected in %s after download", RAW_DIR)
+        return
+
+    logging.info("Kaggle file sizes:")
+    for path in csv_paths:
+        size_mb = path.stat().st_size / (1024 * 1024)
+        logging.info("  %s: %.2f MB", path.relative_to(ROOT), size_mb)
+
+
+def main(argv: list[str] | None = None) -> int:
+    project_root = ROOT
+    src_path = project_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
 
     _configure_numeric_environment()
+    _configure_logging()
 
-    from nba_db import update
+    args = _parse_args(argv or sys.argv[1:])
 
-    timestamp = datetime.now().isoformat(timespec="seconds")
-    print(f"Starting init at {timestamp}")
-    result = update.init()
-    print("Bootstrap completed. Files written:")
-    print(f"  Players: {result.player_path} ({result.row_counts['players']} rows)")
-    print(f"  Teams: {result.team_path} ({result.row_counts['teams']} rows)")
-    print(f"  Games: {result.game_path} ({result.row_counts['games']} rows)")
-    print(
-        f"  Game summaries: {result.game_summary_path} "
-        f"({result.row_counts['game_summaries']} rows)"
-    )
-    print(f"Finished init at {datetime.now().isoformat(timespec='seconds')}")
+    logging.info("Starting Kaggle bootstrap at %s", datetime.now().isoformat(timespec="seconds"))
+
+    _ensure_kaggle_cli()
+    _download_dataset(args.dataset_id, force=args.force)
+    frame = _normalise_game_csv()
+    _log_summary(frame)
+
+    logging.info("Finished Kaggle bootstrap")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/load_duckdb.py
+++ b/scripts/load_duckdb.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Load Kaggle CSV exports into a local DuckDB database."""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import duckdb
+
+
+RAW_DIR = pathlib.Path("data/raw")
+DB_PATH = pathlib.Path("data/nba.duckdb")
+
+
+def _sanitize(stem: str) -> str:
+    """Convert a file stem to a safe DuckDB table name."""
+
+    cleaned = re.sub(r"[^a-z0-9_]+", "_", stem.lower())
+    return f"raw_{cleaned}".strip("_")
+
+
+def main() -> int:
+    if not RAW_DIR.exists():
+        print(f"[ERR] {RAW_DIR} not found. Run run_init.py first.", file=sys.stderr)
+        return 1
+
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(DB_PATH))
+    con.execute("PRAGMA threads=4;")
+
+    for csv_path in RAW_DIR.rglob("*.csv"):
+        table_name = _sanitize(csv_path.stem)
+        print(f"[LOAD] {csv_path} -> {table_name}")
+        con.execute(
+            """
+            CREATE OR REPLACE TABLE %s AS
+            SELECT * FROM read_csv_auto(?, sample_size=-1)
+            """
+            % table_name,
+            [str(csv_path)],
+        )
+
+    # Ensure both raw_game and raw_games exist for downstream SQL compatibility.
+    tables = {name for (name,) in con.execute(
+        "SELECT table_name FROM duckdb_tables() WHERE database_name IS NULL AND schema_name = 'main'"
+    ).fetchall()}
+    if "raw_game" in tables and "raw_games" not in tables:
+        con.execute("CREATE OR REPLACE VIEW raw_games AS SELECT * FROM raw_game")
+        tables.add("raw_games")
+    elif "raw_games" in tables and "raw_game" not in tables:
+        con.execute("CREATE OR REPLACE VIEW raw_game AS SELECT * FROM raw_games")
+        tables.add("raw_game")
+
+    if "raw_player" in tables and "raw_players" not in tables:
+        con.execute("CREATE OR REPLACE VIEW raw_players AS SELECT * FROM raw_player")
+    elif "raw_players" in tables and "raw_player" not in tables:
+        con.execute("CREATE OR REPLACE VIEW raw_player AS SELECT * FROM raw_players")
+
+    print(f"✅ Loaded CSVs into {DB_PATH}")
+
+    summary = con.execute(
+        """
+        SELECT table_name, row_count
+        FROM duckdb_tables()
+        WHERE database_name IS NULL
+          AND schema_name = 'main'
+          AND table_name LIKE 'raw_%'
+        ORDER BY table_name
+        """
+    ).fetchall()
+
+    for table_name, row_count in summary:
+        print(f"  - {table_name:<30} rows={row_count}")
+
+    con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sql/build_schema.sql
+++ b/sql/build_schema.sql
@@ -1,0 +1,127 @@
+PRAGMA threads=4;
+
+CREATE SCHEMA IF NOT EXISTS staging;
+CREATE SCHEMA IF NOT EXISTS marts;
+
+CREATE OR REPLACE VIEW staging.team_game AS
+WITH raw_union AS (
+    SELECT * FROM raw_game
+    UNION
+    SELECT * FROM raw_games
+)
+SELECT
+    CAST(season_id AS VARCHAR) AS season_id,
+    CAST(team_id AS VARCHAR) AS team_id,
+    team_abbreviation,
+    team_name,
+    CAST(game_id AS VARCHAR) AS game_id,
+    CAST(TRY_CAST(game_date AS DATE) AS DATE) AS game_date,
+    matchup,
+    wl,
+    CAST(min AS INTEGER) AS min,
+    CAST(fgm AS DOUBLE) AS fgm,
+    CAST(fga AS DOUBLE) AS fga,
+    CAST(fg_pct AS DOUBLE) AS fg_pct,
+    CAST(fg3m AS DOUBLE) AS fg3m,
+    CAST(fg3a AS DOUBLE) AS fg3a,
+    CAST(fg3_pct AS DOUBLE) AS fg3_pct,
+    CAST(ftm AS DOUBLE) AS ftm,
+    CAST(fta AS DOUBLE) AS fta,
+    CAST(ft_pct AS DOUBLE) AS ft_pct,
+    CAST(oreb AS DOUBLE) AS oreb,
+    CAST(dreb AS DOUBLE) AS dreb,
+    CAST(reb AS DOUBLE) AS reb,
+    CAST(ast AS DOUBLE) AS ast,
+    CAST(stl AS DOUBLE) AS stl,
+    CAST(blk AS DOUBLE) AS blk,
+    CAST(tov AS DOUBLE) AS tov,
+    CAST(pf AS DOUBLE) AS pf,
+    CAST(pts AS DOUBLE) AS pts,
+    CAST(plus_minus AS INTEGER) AS plus_minus,
+    CAST(video_available AS BOOLEAN) AS video_available,
+    COALESCE(season_type, 'Regular Season') AS season_type
+FROM raw_union;
+
+CREATE OR REPLACE VIEW staging.team AS
+SELECT DISTINCT
+    CAST(team_id AS VARCHAR) AS team_id,
+    team_abbreviation,
+    team_name
+FROM staging.team_game;
+
+CREATE OR REPLACE VIEW staging.player AS
+SELECT DISTINCT
+    CAST(player_id AS VARCHAR) AS player_id,
+    player_name,
+    team_id
+FROM (
+    SELECT * FROM raw_player
+    UNION
+    SELECT * FROM raw_players
+)
+WHERE player_id IS NOT NULL;
+
+CREATE OR REPLACE VIEW marts.dim_game AS
+WITH tagged AS (
+    SELECT
+        game_id,
+        MAX(season_id) AS season_id,
+        MAX(season_type) AS season_type,
+        MAX(game_date) AS game_date,
+        MAX(CASE WHEN POSITION('vs.' IN LOWER(matchup)) > 0 THEN team_id END) AS home_team_id,
+        MAX(CASE WHEN POSITION('@' IN LOWER(matchup)) > 0 THEN team_id END) AS away_team_id,
+        SUM(CASE WHEN POSITION('vs.' IN LOWER(matchup)) > 0 THEN pts END) AS home_pts,
+        SUM(CASE WHEN POSITION('@' IN LOWER(matchup)) > 0 THEN pts END) AS away_pts
+    FROM staging.team_game
+    GROUP BY game_id
+)
+SELECT
+    game_id,
+    season_id,
+    season_type,
+    game_date,
+    home_team_id,
+    away_team_id,
+    home_pts,
+    away_pts
+FROM tagged;
+
+CREATE OR REPLACE VIEW marts.fact_team_game AS
+SELECT
+    CAST(game_id AS VARCHAR) AS game_id,
+    CAST(team_id AS VARCHAR) AS team_id,
+    season_id,
+    season_type,
+    game_date,
+    team_abbreviation,
+    team_name,
+    wl,
+    min,
+    fgm,
+    fga,
+    fg_pct,
+    fg3m,
+    fg3a,
+    fg3_pct,
+    ftm,
+    fta,
+    ft_pct,
+    oreb,
+    dreb,
+    reb,
+    ast,
+    stl,
+    blk,
+    tov,
+    pf,
+    pts,
+    plus_minus
+FROM staging.team_game;
+
+CREATE OR REPLACE VIEW marts.dim_team AS
+SELECT DISTINCT team_id, team_abbreviation, team_name
+FROM staging.team;
+
+CREATE OR REPLACE VIEW marts.dim_player AS
+SELECT DISTINCT player_id, player_name, team_id
+FROM staging.player;

--- a/src/nba_db/extract.py
+++ b/src/nba_db/extract.py
@@ -1,0 +1,166 @@
+"""NBA Stats API helpers for incremental game log updates."""
+from __future__ import annotations
+
+import logging
+import random
+import time
+from datetime import date
+from typing import Optional
+
+import pandas as pd
+from nba_api.stats.endpoints import leaguegamelog
+from requests import exceptions as requests_exceptions
+
+from .utils import get_proxies
+
+
+LOGGER = logging.getLogger(__name__)
+
+SEASON_TYPES = [
+    "Regular Season",
+    "Playoffs",
+    "Pre Season",
+    "In Season Tournament",
+]
+
+NBA_API_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+    "Origin": "https://www.nba.com",
+    "Referer": "https://www.nba.com/",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-site",
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    ),
+    "x-nba-stats-origin": "stats",
+    "x-nba-stats-token": "true",
+}
+
+REQUEST_SLEEP_SECONDS = 1.0
+DEFAULT_TIMEOUT = 10
+MAX_RETRIES = 5
+MAX_BACKOFF_SECONDS = 10
+
+
+def _season_year_for_date(value: date) -> int:
+    return value.year if value.month >= 7 else value.year - 1
+
+
+def _season_label(year: int) -> str:
+    return f"{year}-{str(year + 1)[-2:]}"
+
+
+def _latest_started_season_year(today: date) -> int:
+    season_start = date(today.year, 10, 1)
+    return today.year if today >= season_start else today.year - 1
+
+
+def _format_for_api(value: Optional[date]) -> Optional[str]:
+    return value.strftime("%m/%d/%Y") if value else None
+
+
+def _call_with_retry(description: str, func):
+    delay = 4
+    attempts = 0
+    while True:
+        try:
+            return func()
+        except requests_exceptions.RequestException as exc:
+            attempts += 1
+            if attempts >= MAX_RETRIES:
+                raise RuntimeError(f"Failed to fetch {description}") from exc
+            sleep_for = min(delay, MAX_BACKOFF_SECONDS)
+            LOGGER.warning(
+                "%s failed (%s); retrying in %ss", description, exc.__class__.__name__, sleep_for
+            )
+            time.sleep(sleep_for)
+            delay = min(delay * 2, MAX_BACKOFF_SECONDS)
+
+
+def _normalise_frame(frame: pd.DataFrame, season_type: str) -> pd.DataFrame:
+    if frame.empty:
+        frame.columns = [col.lower() for col in frame.columns]
+        frame["season_type"] = season_type
+        return frame
+
+    normalised = frame.copy()
+    normalised.columns = normalised.columns.str.lower()
+    if "game_date" in normalised.columns:
+        normalised["game_date"] = pd.to_datetime(normalised["game_date"], errors="coerce")
+    normalised["season_type"] = season_type
+    return normalised
+
+
+def get_league_game_log_from_date(
+    start: date,
+    end: Optional[date] = None,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> pd.DataFrame:
+    """Fetch league game logs between ``start`` and ``end`` (inclusive)."""
+
+    today = date.today()
+    latest_season_year = _latest_started_season_year(today)
+    effective_end = end or today
+    effective_end_year = min(_season_year_for_date(effective_end), latest_season_year)
+    start_year = _season_year_for_date(start)
+
+    if start_year > latest_season_year:
+        LOGGER.info("Start date %s is in a future season; returning empty frame", start)
+        return pd.DataFrame()
+
+    frames: list[pd.DataFrame] = []
+    proxies = get_proxies()
+
+    for season_year in range(start_year, effective_end_year + 1):
+        season = _season_label(season_year)
+        season_start = date(season_year, 7, 1)
+        season_end = date(season_year + 1, 6, 30)
+        season_from = start if season_year == start_year else season_start
+        season_to = effective_end if season_year == effective_end_year else season_end
+
+        for season_type in SEASON_TYPES:
+            formatted_from = _format_for_api(season_from if season_from >= season_start else season_start)
+            formatted_to = _format_for_api(season_to if season_to <= season_end else season_end)
+
+            proxy = random.choice(proxies) if proxies else None
+
+            def _fetch() -> pd.DataFrame:
+                endpoint = leaguegamelog.LeagueGameLog(
+                    season=season,
+                    season_type_all_star=season_type,
+                    date_from_nullable=formatted_from,
+                    date_to_nullable=formatted_to,
+                    timeout=timeout,
+                    headers=NBA_API_HEADERS,
+                    proxy=proxy,
+                )
+                frames_list = endpoint.get_data_frames()
+                return frames_list[0] if frames_list else pd.DataFrame()
+
+            frame = _call_with_retry(f"leaguegamelog {season} {season_type}", _fetch)
+            if not frame.empty:
+                normalised = _normalise_frame(frame, season_type)
+                frames.append(normalised)
+            time.sleep(REQUEST_SLEEP_SECONDS)
+
+    if not frames:
+        return pd.DataFrame()
+
+    combined = pd.concat(frames, ignore_index=True)
+    if "game_date" in combined.columns:
+        upper_bound = end or effective_end
+        mask = combined["game_date"].isna() | (
+            (combined["game_date"].dt.date >= start) &
+            (combined["game_date"].dt.date <= upper_bound)
+        )
+        combined = combined[mask]
+        combined.reset_index(drop=True, inplace=True)
+    return combined
+
+
+__all__ = ["get_league_game_log_from_date", "SEASON_TYPES"]

--- a/src/nba_db/paths.py
+++ b/src/nba_db/paths.py
@@ -1,0 +1,19 @@
+"""Shared filesystem locations for the lightweight NBA data pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT: Path = Path(__file__).resolve().parents[1]
+"""Repository root resolved at import time."""
+
+
+RAW_DIR: Path = ROOT / "data" / "raw"
+"""Directory containing raw CSV exports."""
+
+
+GAME_CSV: Path = RAW_DIR / "game.csv"
+"""Canonical location of the consolidated per-team game log."""
+
+
+__all__ = ["ROOT", "RAW_DIR", "GAME_CSV"]

--- a/src/nba_db/update.py
+++ b/src/nba_db/update.py
@@ -1,386 +1,172 @@
-"""Data ingestion helpers emulating the ``wyattowalsh/nbadb`` project."""
+"""Incremental game log updater built around the Kaggle bootstrap seed."""
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Callable, Iterable, Optional, Sequence
+from typing import Optional
 
 import pandas as pd
-import time
-from requests import exceptions as requests_exceptions
-try:  # pragma: no cover - optional dependency in the lightweight environment
-    import yaml
-except ModuleNotFoundError:  # pragma: no cover
-    yaml = None  # type: ignore[assignment]
-from nba_api.stats.static import players as static_players
-from nba_api.stats.static import teams as static_teams
-from nba_api.stats.endpoints import (
-    boxscoresummaryv2,
-    commonplayerinfo,
-    leaguegamelog,
-    teaminfocommon,
-)
 
-CONFIG_FILENAME = "config.yaml"
-SEASON_TYPES: tuple[str, ...] = (
-    "Regular Season",
-    "Playoffs",
-    "Pre Season",
-    "PlayIn",
-)
+from . import extract
+from .paths import GAME_CSV, RAW_DIR
 
 
-NBA_API_HEADERS = {
-    "Accept": "application/json, text/plain, */*",
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
-    ),
-    "x-nba-stats-origin": "stats",
-    "Referer": "https://stats.nba.com/",
-}
+LOGGER = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT = 10
+GAME_LOG_PRIMARY_KEY = ("game_id", "team_id", "season_type")
+DEFAULT_SEASON_TYPE = "Regular Season"
 
 
-@dataclass
+@dataclass(slots=True)
 class DailyUpdateResult:
     """Summary describing a ``daily`` update."""
 
     output_path: Path
     rows_written: int
     appended: bool
+    final_row_count: int
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> dict[str, object]:  # pragma: no cover - helper for scripts/CLI
         return {
             "output_path": str(self.output_path),
             "rows_written": self.rows_written,
             "appended": self.appended,
+            "final_row_count": self.final_row_count,
         }
 
 
-@dataclass
-class InitResult:
-    """Outcome of the initial bootstrap."""
-
-    player_path: Path
-    team_path: Path
-    game_path: Path
-    game_summary_path: Path
-    row_counts: dict[str, int]
+def _ensure_raw_dir() -> None:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _project_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _parse_yaml_fallback(text: str) -> dict[str, object]:
-    config: dict[str, object] = {}
-    stack: list[tuple[int, dict[str, object]]] = [(-1, config)]
-    for raw_line in text.splitlines():
-        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
-            continue
-        indent = len(raw_line) - len(raw_line.lstrip())
-        line = raw_line.strip()
-        if ":" not in line:
-            raise ValueError(f"Invalid config line: {raw_line!r}")
-        key, value = line.split(":", 1)
-        key = key.strip()
-        value = value.strip()
-        while stack and indent <= stack[-1][0]:
-            stack.pop()
-        current = stack[-1][1]
-        if not value:
-            nested: dict[str, object] = {}
-            current[key] = nested
-            stack.append((indent, nested))
-            continue
-        if value[0] in {'"', "'"} and value[-1] == value[0]:
-            value = value[1:-1]
-        current[key] = value
-    return config
-
-
-def _load_config(config_path: Optional[Path] = None) -> dict[str, object]:
-    path = config_path or _project_root() / CONFIG_FILENAME
-    if not path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {path}")
-    with path.open("r", encoding="utf-8") as handle:
-        text = handle.read()
-    if yaml is not None:
-        config = yaml.safe_load(text) or {}
-    else:
-        config = _parse_yaml_fallback(text)
-    return config
-
-
-def _resolve_raw_dir(config: dict[str, object], override: Optional[Path | str] = None) -> Path:
-    if override is not None:
-        raw_dir = Path(override)
-        return raw_dir if raw_dir.is_absolute() else _project_root() / raw_dir
-
-    raw_section = config.get("raw") if isinstance(config, dict) else None
-    if not isinstance(raw_section, dict):
-        raise KeyError("Configuration is missing 'raw' section")
-    raw_dir_value = raw_section.get("raw_dir")
-    if raw_dir_value is None:
-        raise KeyError("Configuration is missing 'raw.raw_dir'")
-    raw_dir = Path(raw_dir_value)
-    return raw_dir if raw_dir.is_absolute() else _project_root() / raw_dir
-
-
-def _season_start(year: int) -> date:
-    return date(year, 7, 1)
-
-
-def _season_end(year: int) -> date:
-    return date(year + 1, 6, 30)
-
-
-def _season_label(year: int) -> str:
-    return f"{year}-{str(year + 1)[-2:]}"
-
-
-def _season_range(start: date, end: date) -> Iterable[int]:
-    start_year = start.year if start.month >= 7 else start.year - 1
-    end_year = end.year if end.month >= 7 else end.year - 1
-    for season_year in range(start_year, end_year + 1):
-        yield season_year
-
-
-def _format_for_api(value: date) -> str:
-    return value.strftime("%m/%d/%Y")
-
-
-def _fetch_season_frame(
-    season: str,
-    *,
-    date_from: Optional[date] = None,
-    date_to: Optional[date] = None,
-) -> pd.DataFrame:
-    frames: list[pd.DataFrame] = []
-    from_str = _format_for_api(date_from) if date_from else None
-    to_str = _format_for_api(date_to) if date_to else None
-    for season_type in SEASON_TYPES:
-        frame = _call_with_retry(
-            f"league game log {season} ({season_type})",
-            lambda st=season_type: leaguegamelog.LeagueGameLog(
-                league_id="00",
-                season=season,
-                season_type_all_star=st,
-                date_from_nullable=from_str,
-                date_to_nullable=to_str,
-                headers=NBA_API_HEADERS,
-                timeout=DEFAULT_TIMEOUT,
-            ).get_data_frames()[0],
-        )
-        if not frame.empty:
-            frame.insert(0, "SEASON_TYPE", season_type)
-            frames.append(frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
-
-
-def get_league_game_log_all() -> pd.DataFrame:
-    today = date.today()
-    start = date(1946, 11, 1)
-    frames: list[pd.DataFrame] = []
-    for season_year in _season_range(start, today):
-        season = _season_label(season_year)
-        season_frame = _fetch_season_frame(season)
-        if not season_frame.empty:
-            frames.append(season_frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
-
-
-def get_league_game_log_from_date(
-    start_date: date,
-    end_date: Optional[date] = None,
-) -> pd.DataFrame:
-    end_date = end_date or date.today()
-    frames: list[pd.DataFrame] = []
-    for season_year in _season_range(start_date, end_date):
-        season = _season_label(season_year)
-        season_start = max(start_date, _season_start(season_year))
-        season_end = min(end_date, _season_end(season_year))
-        season_frame = _fetch_season_frame(
-            season,
-            date_from=season_start,
-            date_to=season_end,
-        )
-        if not season_frame.empty:
-            frames.append(season_frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
-
-
-def _infer_game_date(series: pd.Series) -> pd.Series:
-    for column in ("GAME_DATE", "GAME_DATE_EST", "GAME_DATE_TIME_EST"):
-        if column in series:
-            return pd.to_datetime(series[column], errors="coerce")
-    raise KeyError("Game log does not contain a date column")
-
-
-def _next_start_date(game_csv_path: Path) -> date:
-    if not game_csv_path.exists():
-        raise FileNotFoundError(
-            "Cannot infer start date because game.csv does not exist."
-        )
-    frame = pd.read_csv(game_csv_path)
+def _canonicalise(frame: pd.DataFrame) -> pd.DataFrame:
     if frame.empty:
-        raise ValueError("Existing game.csv is empty")
-    dates = _infer_game_date(frame)
-    last = dates.dropna().max()
-    if pd.isna(last):
-        raise ValueError("Unable to infer last game date from game.csv")
-    return (last.date() + timedelta(days=1))
+        frame.columns = [col.lower() for col in frame.columns]
+        return frame
 
-
-def _write_dataframe(path: Path, frame: pd.DataFrame, *, append: bool) -> int:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if append and path.exists():
-        frame.to_csv(path, mode="a", header=False, index=False)
+    canonical = frame.copy()
+    canonical.columns = canonical.columns.str.lower()
+    if "game_date" in canonical.columns:
+        canonical["game_date"] = pd.to_datetime(canonical["game_date"], errors="coerce")
+    if "season_type" not in canonical.columns:
+        canonical["season_type"] = DEFAULT_SEASON_TYPE
     else:
-        frame.to_csv(path, index=False)
-    return len(frame)
-
-
-def _call_with_retry(description: str, func: Callable[[], pd.DataFrame]) -> pd.DataFrame:
-    last_error: Optional[Exception] = None
-    for attempt in range(3):
-        try:
-            return func()
-        except requests_exceptions.RequestException as exc:  # pragma: no cover - network
-            last_error = exc
-            time.sleep(2 ** attempt)
-    if last_error is not None:  # pragma: no cover - network
-        raise RuntimeError(f"Failed to fetch {description}") from last_error
-    raise RuntimeError(f"Failed to fetch {description}")
-
-
-def _fetch_all_players() -> pd.DataFrame:
-    players = static_players.get_players()
-    frames: list[pd.DataFrame] = []
-    for meta in players:
-        frame = _call_with_retry(
-            f"player {meta['id']}",
-            lambda meta_id=meta["id"]: commonplayerinfo.CommonPlayerInfo(
-                player_id=meta_id,
-                headers=NBA_API_HEADERS,
-                timeout=DEFAULT_TIMEOUT,
-            ).get_data_frames()[0],
+        canonical["season_type"] = (
+            canonical["season_type"].fillna(DEFAULT_SEASON_TYPE).replace("", DEFAULT_SEASON_TYPE)
         )
-        if not frame.empty:
-            frames.append(frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
+    for column in ("season_id", "game_id", "team_id"):
+        if column not in canonical.columns:
+            continue
+        series = canonical[column].astype(str).str.strip()
+        if column in {"game_id", "team_id"}:
+            series = series.str.lstrip("0").replace({"": "0"})
+        canonical[column] = series
+    return canonical
 
 
-def _fetch_all_teams() -> pd.DataFrame:
-    teams = static_teams.get_teams()
-    frames: list[pd.DataFrame] = []
-    for meta in teams:
-        frame = _call_with_retry(
-            f"team {meta['id']}",
-            lambda meta_id=meta["id"]: teaminfocommon.TeamInfoCommon(
-                team_id=meta_id,
-                headers=NBA_API_HEADERS,
-                timeout=DEFAULT_TIMEOUT,
-            ).get_data_frames()[0],
+def _read_existing(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} not found. Run run_init.py first to download the Kaggle seed dataset."
         )
-        if not frame.empty:
-            frames.append(frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
+
+    frame = pd.read_csv(path)
+    if frame.empty:
+        frame.columns = [col.lower() for col in frame.columns]
+        return frame
+    return _canonicalise(frame)
 
 
-def _fetch_game_summaries(game_ids: Sequence[str]) -> pd.DataFrame:
-    frames: list[pd.DataFrame] = []
-    for game_id in game_ids:
-        frame = _call_with_retry(
-            f"game summary {game_id}",
-            lambda gid=game_id: boxscoresummaryv2.BoxScoreSummaryV2(
-                game_id=gid,
-                headers=NBA_API_HEADERS,
-                timeout=DEFAULT_TIMEOUT,
-            ).get_data_frames()[0],
-        )
-        if not frame.empty:
-            frames.append(frame)
-    if not frames:
-        return pd.DataFrame()
-    return pd.concat(frames, ignore_index=True)
+def _latest_game_date(frame: pd.DataFrame) -> Optional[date]:
+    if "game_date" not in frame.columns:
+        return None
+    valid = frame["game_date"].dropna()
+    if valid.empty:
+        return None
+    return valid.max().date()
+
+
+def _deduplicate(frame: pd.DataFrame) -> pd.DataFrame:
+    subset = [column for column in GAME_LOG_PRIMARY_KEY if column in frame.columns]
+    if not subset:
+        return frame.drop_duplicates(ignore_index=True)
+    return frame.drop_duplicates(subset=subset, keep="first", ignore_index=True)
+
+
+def _atomic_write_csv(frame: pd.DataFrame, path: Path) -> None:
+    tmp_path = path.with_suffix(".tmp")
+    frame.to_csv(tmp_path, index=False)
+    os.replace(tmp_path, path)
+
+
+def _log_fetch_window(new_rows: pd.DataFrame) -> None:
+    if "game_date" not in new_rows.columns:
+        LOGGER.info("Fetched %s new rows (game_date column missing)", len(new_rows))
+        return
+
+    valid_dates = new_rows["game_date"].dropna()
+    if valid_dates.empty:
+        LOGGER.info("Fetched %s new rows with unknown game_date values", len(new_rows))
+        return
+
+    window = f"{valid_dates.min().date()} → {valid_dates.max().date()}"
+    LOGGER.info("Fetched %s new rows covering %s", len(new_rows), window)
 
 
 def daily(
     *,
-    fetch_all_history: bool = False,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    output_dir: Optional[Path | str] = None,
 ) -> DailyUpdateResult:
-    config = _load_config()
-    raw_dir = _resolve_raw_dir(config, override=output_dir)
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    game_csv_path = raw_dir / "game.csv"
+    """Fetch and append the latest NBA games into ``data/raw/game.csv``."""
 
-    if fetch_all_history:
-        frame = get_league_game_log_all()
-        rows = _write_dataframe(game_csv_path, frame, append=False)
-        return DailyUpdateResult(game_csv_path, rows, appended=False)
+    _ensure_raw_dir()
 
-    start = date.fromisoformat(start_date) if start_date else _next_start_date(game_csv_path)
-    stop = date.fromisoformat(end_date) if end_date else None
-    frame = get_league_game_log_from_date(start, stop)
-    if frame.empty:
-        return DailyUpdateResult(game_csv_path, 0, appended=game_csv_path.exists())
-    rows = _write_dataframe(game_csv_path, frame, append=game_csv_path.exists())
-    return DailyUpdateResult(game_csv_path, rows, appended=game_csv_path.exists())
+    existing = _read_existing(GAME_CSV)
 
+    today_local = date.today()
 
-def init(output_dir: Optional[Path | str] = None) -> InitResult:
-    config = _load_config()
-    raw_dir = _resolve_raw_dir(config, override=output_dir)
-    raw_dir.mkdir(parents=True, exist_ok=True)
+    if start_date:
+        fetch_from = date.fromisoformat(start_date)
+    else:
+        latest = _latest_game_date(existing)
+        if latest is None:
+            raise RuntimeError(
+                "Existing game.csv does not contain any valid game_date values; cannot resume update"
+            )
+        fetch_from = latest + timedelta(days=1)
 
-    player_path = raw_dir / "common_player_info.csv"
-    team_path = raw_dir / "team_info_common.csv"
-    game_path = raw_dir / "game.csv"
-    game_summary_path = raw_dir / "game_summary.csv"
+    if end_date:
+        fetch_until = date.fromisoformat(end_date)
+    else:
+        fetch_until = None
 
-    players_frame = _fetch_all_players()
-    teams_frame = _fetch_all_teams()
-    games_frame = get_league_game_log_all()
-    summaries_frame = _fetch_game_summaries(games_frame["GAME_ID"].tolist()) if not games_frame.empty else pd.DataFrame()
+    if fetch_from >= today_local:
+        LOGGER.info("No new games to fetch; latest recorded date is %s", (fetch_from - timedelta(days=1)))
+        return DailyUpdateResult(GAME_CSV, 0, appended=True, final_row_count=len(existing))
 
-    row_counts = {
-        "players": _write_dataframe(player_path, players_frame, append=False) if not players_frame.empty else 0,
-        "teams": _write_dataframe(team_path, teams_frame, append=False) if not teams_frame.empty else 0,
-        "games": _write_dataframe(game_path, games_frame, append=False) if not games_frame.empty else 0,
-        "game_summaries": _write_dataframe(game_summary_path, summaries_frame, append=False) if not summaries_frame.empty else 0,
-    }
+    new_rows = extract.get_league_game_log_from_date(fetch_from, fetch_until)
+    new_rows = _canonicalise(new_rows)
 
-    return InitResult(
-        player_path=player_path,
-        team_path=team_path,
-        game_path=game_path,
-        game_summary_path=game_summary_path,
-        row_counts=row_counts,
-    )
+    if new_rows.empty:
+        LOGGER.info("NBA API returned no games for %s onward", fetch_from.isoformat())
+        return DailyUpdateResult(GAME_CSV, 0, appended=True, final_row_count=len(existing))
+
+    _log_fetch_window(new_rows)
+
+    combined = pd.concat([existing, new_rows], ignore_index=True)
+    combined = _deduplicate(combined)
+
+    _atomic_write_csv(combined, GAME_CSV)
+    final_count = len(combined)
+    appended_rows = max(final_count - len(existing), 0)
+
+    LOGGER.info("Final game.csv row count: %s", final_count)
+
+    return DailyUpdateResult(GAME_CSV, appended_rows, appended=True, final_row_count=final_count)
 
 
-__all__ = [
-    "DailyUpdateResult",
-    "InitResult",
-    "daily",
-    "get_league_game_log_all",
-    "get_league_game_log_from_date",
-    "init",
-]
+__all__ = ["DailyUpdateResult", "daily"]

--- a/src/nba_db/utils.py
+++ b/src/nba_db/utils.py
@@ -1,0 +1,11 @@
+"""Miscellaneous helpers for the lightweight NBA data pipeline."""
+from __future__ import annotations
+
+
+def get_proxies() -> list[str]:
+    """Return configured HTTP proxies for stats.nba.com requests."""
+
+    return []
+
+
+__all__ = ["get_proxies"]

--- a/src/nbapredictor/nbadb_sync.py
+++ b/src/nbapredictor/nbadb_sync.py
@@ -31,9 +31,28 @@ HISTORICAL_START_DATE = date(1946, 11, 1)
 SEASON_TYPES: tuple[str, ...] = (
     "Regular Season",
     "Playoffs",
-    "PlayIn",
     "Pre Season",
+    "In Season Tournament",
 )
+
+NBA_API_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+    "Origin": "https://www.nba.com",
+    "Referer": "https://www.nba.com/",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-site",
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    ),
+    "x-nba-stats-origin": "stats",
+    "x-nba-stats-token": "true",
+}
+
+DEFAULT_TIMEOUT = 15
 
 
 @dataclass
@@ -161,6 +180,8 @@ def _fetch_game_logs_for_date(target_date: date, retries: int = 3, pause: float 
                     season_type_all_star=season_type,
                     date_from_nullable=date_str,
                     date_to_nullable=date_str,
+                    headers=NBA_API_HEADERS,
+                    timeout=DEFAULT_TIMEOUT,
                 )
                 frame = endpoint.get_data_frames()[0]
                 if not frame.empty:
@@ -213,6 +234,8 @@ def _fetch_game_logs_for_season(season: str, retries: int = 3, pause: float = 1.
                     league_id="00",
                     season=season,
                     season_type_all_star=season_type,
+                    headers=NBA_API_HEADERS,
+                    timeout=DEFAULT_TIMEOUT,
                 )
                 frame = endpoint.get_data_frames()[0]
                 if not frame.empty:
@@ -467,7 +490,7 @@ def update_raw_data(
 
     stop = _parse_date(end_date)
     if stop is None:
-        stop = date.today() - timedelta(days=1)
+        stop = date.today()
 
     if fetch_all_history:
         start = HISTORICAL_START_DATE

--- a/tests/test_nbadb_sync.py
+++ b/tests/test_nbadb_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import types
 from datetime import date
 from pathlib import Path
 
@@ -142,3 +143,112 @@ def test_bootstrap_kaggle_imports_dataset(tmp_path, monkeypatch):
     assert manifest["last_updated"] == "2024-10-26"
     assert set(manifest["historical_seasons"]) >= {"2023-24", "2024-25"}
     assert manifest["bootstrap"]["dataset"] == nbadb_sync.KAGGLE_DATASET_ID
+
+
+def test_bootstrap_kaggle_dump_invokes_cli(tmp_path, monkeypatch):
+    commands: list[tuple[tuple[str, ...], bool]] = []
+
+    def fake_which(executable: str) -> str:
+        assert executable == "kaggle"
+        return "/usr/bin/kaggle"
+
+    def fake_run(args, *, check):
+        commands.append((tuple(args), check))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(nbadb_sync.shutil, "which", fake_which)
+    monkeypatch.setattr(nbadb_sync.subprocess, "run", fake_run)
+
+    destination = tmp_path / "dataset"
+    result = nbadb_sync.bootstrap_kaggle_dump(destination)
+
+    assert result == destination
+    assert destination.exists()
+    assert commands == [
+        (
+            (
+                "kaggle",
+                "datasets",
+                "download",
+                "--unzip",
+                "-p",
+                str(destination),
+                "-d",
+                nbadb_sync.KAGGLE_DATASET_ID,
+            ),
+            True,
+        )
+    ]
+
+
+def test_bootstrap_kaggle_dump_missing_cli(tmp_path, monkeypatch):
+    monkeypatch.setattr(nbadb_sync.shutil, "which", lambda executable: None)
+
+    with pytest.raises(FileNotFoundError):
+        nbadb_sync.bootstrap_kaggle_dump(tmp_path / "dataset")
+
+
+def test_fetch_game_logs_for_date_uses_headers_and_timeout(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_leaguegamelog(*, league_id, season, season_type_all_star, date_from_nullable, date_to_nullable, headers, timeout):
+        calls.append(
+            {
+                "league_id": league_id,
+                "season": season,
+                "season_type": season_type_all_star,
+                "headers": headers,
+                "timeout": timeout,
+                "date_from": date_from_nullable,
+                "date_to": date_to_nullable,
+            }
+        )
+        return types.SimpleNamespace(
+            get_data_frames=lambda: [pd.DataFrame({"GAME_ID": ["1"], "SEASON_ID": ["1"]})]
+        )
+
+    monkeypatch.setattr(nbadb_sync.leaguegamelog, "LeagueGameLog", fake_leaguegamelog)
+
+    frame = nbadb_sync._fetch_game_logs_for_date(date(2024, 10, 5), retries=1)
+
+    assert not frame.empty
+    assert {call["season_type"] for call in calls} == set(nbadb_sync.SEASON_TYPES)
+    assert all(call["headers"] == nbadb_sync.NBA_API_HEADERS for call in calls)
+    assert all(call["timeout"] == nbadb_sync.DEFAULT_TIMEOUT for call in calls)
+
+
+def test_update_raw_data_defaults_to_today(monkeypatch, tmp_path):
+    class FakeDate(date):
+        @classmethod
+        def today(cls) -> "FakeDate":
+            return cls(2024, 10, 5)
+
+    processed: list[date] = []
+
+    def fake_fetch_game_logs(target_date: date) -> pd.DataFrame:
+        processed.append(target_date)
+        return pd.DataFrame(
+            {
+                "GAME_ID": [target_date.strftime("%Y%m%d")],
+                "TEAM_ID": ["1610612737"],
+                "GAME_DATE": [target_date.isoformat()],
+            }
+        )
+
+    manifest_path = tmp_path / nbadb_sync.MANIFEST_FILENAME
+    manifest_path.write_text(json.dumps({"last_updated": "2024-10-03"}))
+
+    monkeypatch.setattr(nbadb_sync, "date", FakeDate)
+    monkeypatch.setattr(nbadb_sync, "_fetch_game_logs_for_date", fake_fetch_game_logs)
+    monkeypatch.setattr(
+        nbadb_sync, "fetch_dataset_metadata", lambda session=None: {"title": "NBA Database"}
+    )
+
+    summary = nbadb_sync.update_raw_data(output_dir=tmp_path)
+
+    assert summary.processed_dates == [date(2024, 10, 4), date(2024, 10, 5)]
+    assert processed == summary.processed_dates
+    assert len(summary.downloaded_files) == 2
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["last_updated"] == "2024-10-05"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -6,79 +6,64 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from nba_db import update as nba_update
+from nba_db import paths, update as nba_update
 
 import run_daily_update
 
 
 @pytest.fixture(autouse=True)
-def _set_config(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("raw:\n  raw_dir: data/raw\n", encoding="utf-8")
-    monkeypatch.setattr(nba_update, "_project_root", lambda: tmp_path)
+def _override_paths(tmp_path, monkeypatch):
+    raw_dir = tmp_path / "data" / "raw"
+    game_csv = raw_dir / "game.csv"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(paths, "RAW_DIR", raw_dir, raising=False)
+    monkeypatch.setattr(paths, "GAME_CSV", game_csv, raising=False)
+    monkeypatch.setattr(nba_update, "RAW_DIR", raw_dir, raising=False)
+    monkeypatch.setattr(nba_update, "GAME_CSV", game_csv, raising=False)
     yield
 
 
-def test_daily_fetch_all_history(monkeypatch, tmp_path):
-    frame = pd.DataFrame({"GAME_ID": ["0001"], "GAME_DATE": ["2020-01-01"]})
-    records: list[dict[str, object]] = []
-
-    def fake_get_all():
-        records.append({"called": True})
-        return frame
-
-    monkeypatch.setattr(nba_update, "get_league_game_log_all", fake_get_all)
-
-    result = nba_update.daily(fetch_all_history=True)
-
-    assert records == [{"called": True}]
-    assert result.output_path == tmp_path / "data/raw/game.csv"
-    saved = pd.read_csv(result.output_path)
-    expected = frame.copy()
-    saved["GAME_ID"] = saved["GAME_ID"].astype(int)
-    expected["GAME_ID"] = expected["GAME_ID"].astype(int)
-    pd.testing.assert_frame_equal(saved, expected, check_dtype=False)
+def test_build_parser_supports_overrides():
+    parser = run_daily_update._build_parser()
+    args = parser.parse_args(["--start-date", "2020-01-01", "--end-date", "2020-01-07"])
+    assert args.start_date == "2020-01-01"
+    assert args.end_date == "2020-01-07"
 
 
-@pytest.mark.parametrize(
-    "argv, expected",
-    [
-        ([], (False, None)),
-        (["--fetch-all-history"], (True, None)),
-        (["2020-10-01"], (False, "2020-10-01")),
-    ],
-)
-def test_parse_args(argv, expected):
-    assert run_daily_update._parse_args(argv) == expected
-
-
-def test_run_daily_update_calls_daily(monkeypatch):
+def test_run_daily_update_calls_update(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_daily(*, fetch_all_history=False, start_date=None, **kwargs):
-        calls.append({
-            "fetch_all_history": fetch_all_history,
-            "start_date": start_date,
-        })
-        return nba_update.DailyUpdateResult(Path("game.csv"), 0, False)
+    def fake_daily(*, start_date=None, end_date=None):
+        calls.append({"start_date": start_date, "end_date": end_date})
+        return nba_update.DailyUpdateResult(Path("game.csv"), 0, True, 5)
 
     monkeypatch.setattr(nba_update, "daily", fake_daily)
 
-    run_daily_update.main(["--fetch-all-history"])
+    exit_code = run_daily_update.main(["--start-date", "2020-01-02"])
 
-    assert calls == [{"fetch_all_history": True, "start_date": None}]
+    assert exit_code == 0
+    assert calls == [{"start_date": "2020-01-02", "end_date": None}]
 
 
 def test_run_daily_update_sets_numeric_environment(monkeypatch):
-    def fake_daily(**kwargs):  # noqa: ARG001 - behaviour under test
-        return nba_update.DailyUpdateResult(Path("game.csv"), 0, False)
+    def fake_daily(*, start_date=None, end_date=None):  # noqa: ARG001
+        return nba_update.DailyUpdateResult(Path("game.csv"), 0, True, 0)
 
     monkeypatch.setattr(nba_update, "daily", fake_daily)
 
     for key in run_daily_update._NUMERIC_ENV_DEFAULTS:
         monkeypatch.delenv(key, raising=False)
 
-    run_daily_update.main([])
+    exit_code = run_daily_update.main([])
 
+    assert exit_code == 0
     for key, value in run_daily_update._NUMERIC_ENV_DEFAULTS.items():
         assert os.environ[key] == value
+
+
+def test_daily_result_written(tmp_path):
+    # Ensure atomic writer is reachable from script tests
+    frame = pd.DataFrame({"game_id": ["0001"], "team_id": ["T1"], "season_type": ["Regular Season"], "game_date": ["2020-01-01"]})
+    nba_update._atomic_write_csv(nba_update._canonicalise(frame), nba_update.GAME_CSV)
+    saved = pd.read_csv(nba_update.GAME_CSV)
+    assert len(saved) == 1


### PR DESCRIPTION
## Summary
- convert `run_init.py` into a Kaggle-only bootstrap that normalises the seed game log and logs outputs
- rewrite the daily updater around the new extract helpers so resume runs deduplicate canonically and stay within the raw data tree
- refresh the CLI, validation helper, and tests to use repo-relative paths and the new schema expectations
- add a DuckDB loader plus staging/mart views and convenience make targets for rebuilding the analytical schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3313e7630832da5be1a3294ad293f